### PR TITLE
CI/CD Workflow refactor and Schema update

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -3,9 +3,14 @@ name: CD
 on:
   push:
     branches: [main]
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -25,6 +30,7 @@ jobs:
       - name: Run Prisma migrations on Supabase
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DIRECT_URL: ${{ secrets.DIRECT_URL }}
         run: npx prisma migrate deploy
 
       - name: Seed database

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -43,6 +43,7 @@ jobs:
 
     env:
       DATABASE_URL: "postgresql://user:password@localhost:5432/db"
+      DIRECT_URL: "postgresql://user:password@localhost:5432/db"
 
     steps:
       - name: Display workflow context info

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model User {


### PR DESCRIPTION
Refactored Prisma Schema and CI/CD workflows to now use new/separate DIRECT and DATABASE URLs, as previously set single general URL did not function for Supabase migration application and seeding.